### PR TITLE
Remove usage of a `box` inside a recover

### DIFF
--- a/.release-notes/recover-fix.md
+++ b/.release-notes/recover-fix.md
@@ -1,0 +1,3 @@
+## Update to work with Pony 0.56.3
+
+Pony 0.56.3 has a bug fix that uncovered what should have been a compilation error in `peg`. We've updated to fix the error.

--- a/peg/many.pony
+++ b/peg/many.pony
@@ -104,11 +104,13 @@ class Many is Parser
     end
 
   fun error_msg(): String =>
+    let sinp = _sep isnt NoParser
+
     recover
       let s = String
       if _require then s.append("at least one ") end
       s.append("element")
-      if _sep isnt NoParser then
+      if sinp then
         s.append(" without a trailing separator")
       end
       s


### PR DESCRIPTION
We recently fixed a bug in the ponyc compiler that allowed you to use a `box` inside a recover. When that was fixed, peg no longer compiled.