### PR TITLE
Add support for not outputting color to terminal

### DIFF
--- a/.release-notes/44.md
+++ b/.release-notes/44.md
@@ -1,0 +1,3 @@
+## Add support for not outputting color to terminal
+
+This is required when the output is piped into a file or a program.

--- a/.release-notes/44.md
+++ b/.release-notes/44.md
@@ -1,3 +1,14 @@
-## Add support for not outputting color to terminal
+## Add support for not colorizing the terminal output
 
-This is required when the output is piped into a file or a program.
+Prior to this change any error message called via `PegFormatError.console`
+would return an error message with ANSI escape sequence code for coloring. This
+created a problem when piping the output to something other than a terminal.
+
+This change adds the ability to remove ANSI escape sequence codes from the
+output. The change is non-breaking as the default behavior is to colorize
+the output. The colorization can be turned off by supplying `false` to
+the `colorize` parameter:
+
+```pony
+PegFormatError.console(error, false)
+```

--- a/peg/pegerror.pony
+++ b/peg/pegerror.pony
@@ -97,12 +97,12 @@ primitive MalformedAST is PegError
     """
 
 primitive PegFormatError
-  fun console(e: PegError val): ByteSeqIter =>
+  fun console(e: PegError val, no_color: Bool = false): ByteSeqIter =>
     let text =
       recover
-        [ ANSI.cyan()
+        [ if no_color then "" else ANSI.cyan() end
           "-- "; e.category(); " --\n\n"
-          ANSI.reset()
+          if no_color then "" else ANSI.reset() end
         ]
       end
 
@@ -121,16 +121,16 @@ primitive PegFormatError
 
       text.append(
         recover
-          [ ANSI.grey()
+          [ if no_color then "" else ANSI.grey() end
             m._1.path; ":"; line_text; ":"; col.string(); ":"; m._3.string()
             "\n\n"
             line_text; ": "
-            ANSI.reset()
+            if no_color then "" else ANSI.reset() end
             source; "\n"
-            ANSI.red()
+            if no_color then "" else ANSI.red() end
             line_indent; "  "; indent; consume mark; "\n"
             line_indent; "  "; indent; m._4
-            ANSI.reset()
+            if no_color then "" else ANSI.reset() end
             "\n\n"
           ]
         end

--- a/peg/pegerror.pony
+++ b/peg/pegerror.pony
@@ -97,12 +97,12 @@ primitive MalformedAST is PegError
     """
 
 primitive PegFormatError
-  fun console(e: PegError val, no_color: Bool = false): ByteSeqIter =>
+  fun console(e: PegError val, colorize: Bool = true): ByteSeqIter =>
     let text =
       recover
-        [ if no_color then "" else ANSI.cyan() end
+        [ if colorize then ANSI.cyan() else "" end
           "-- "; e.category(); " --\n\n"
-          if no_color then "" else ANSI.reset() end
+          if colorize then ANSI.reset() else "" end
         ]
       end
 
@@ -121,16 +121,16 @@ primitive PegFormatError
 
       text.append(
         recover
-          [ if no_color then "" else ANSI.grey() end
+          [ if colorize then ANSI.grey() else "" end
             m._1.path; ":"; line_text; ":"; col.string(); ":"; m._3.string()
             "\n\n"
             line_text; ": "
-            if no_color then "" else ANSI.reset() end
+            if colorize then ANSI.reset() else "" end
             source; "\n"
-            if no_color then "" else ANSI.red() end
+            if colorize then ANSI.red() else "" end
             line_indent; "  "; indent; consume mark; "\n"
             line_indent; "  "; indent; m._4
-            if no_color then "" else ANSI.reset() end
+            if colorize then ANSI.reset() else "" end
             "\n\n"
           ]
         end


### PR DESCRIPTION
This is required when the output is piped into a file or a program.

Here is a more general approach via an environment variable `NO_COLOR` <https://no-color.org/>. I decided to only include a boolean option since this function is exposed for user code and not internal to the package.