### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/examples/compiler/main.pony
+++ b/examples/compiler/main.pony
@@ -59,7 +59,7 @@ actor Main
       let auth = FileAuth(env.root)
       let peg = Source(FilePath(auth, peg_filename))?
 
-      match recover val PegCompiler(peg) end
+      match \exhaustive\ recover val PegCompiler(peg) end
       | let p: Parser val =>
         peg_run(p, target_filename, auth, env.out)
       | let errors: Array[PegError] val =>

--- a/peg/_test.pony
+++ b/peg/_test.pony
@@ -24,7 +24,7 @@ class \nodoc\ iso _TestFromFile is UnitTest
     let peg_file = FilePath(auth, "examples/" + _example + ".peg")
     let test_file = FilePath(auth, "test/" + _test)
     let expect_file = FilePath(auth, "test/" + _expect)
-    match recover val PegCompiler(Source(peg_file)?) end
+    match \exhaustive\ recover val PegCompiler(Source(peg_file)?) end
     | let p: Parser val =>
       let out = peg_run(h, p, Source(test_file)?)?
       with file = OpenFile(expect_file) as File do

--- a/peg/pegcompiler.pony
+++ b/peg/pegcompiler.pony
@@ -184,7 +184,7 @@ primitive PegCompiler
         elseif rune == '\\' then
           escape = true
         elseif hex > 0 then
-          hexrune = (hexrune << 8) or match rune
+          hexrune = (hexrune << 8) or match \exhaustive\ rune
           | if (rune >= '0') and (rune <= '9') => rune - '0'
           | if (rune >= 'a') and (rune <= 'f') => (rune - 'a') + 10
           else (rune - 'A') + 10 end

--- a/peg/sequence.pony
+++ b/peg/sequence.pony
@@ -32,7 +32,7 @@ class Sequence is Parser
     let ast = AST(_label)
 
     for p in _seq.values() do
-      match p.parse(source, offset + length, true, hidden)
+      match \exhaustive\ p.parse(source, offset + length, true, hidden)
       | (let advance: USize, Skipped) =>
         length = length + advance
       | (let advance: USize, let r: (Token | NotPresent)) =>
@@ -55,7 +55,7 @@ class Sequence is Parser
       end
     end
 
-    match ast.size()
+    match \exhaustive\ ast.size()
     | 0 if _label is NoLabel => (length, Skipped)
     | 1 if _label is NoLabel => (length, ast.extract())
     else


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.