### PR TITLE
Add documentation to all public API elements

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# Examples
+
+Each entry demonstrates a different aspect of the peg library. Build all
+examples with `make build-examples`.
+
+## [compiler](compiler/)
+
+A CLI tool that parses files using the library's built-in parsers or a
+custom-compiled grammar. With one argument, it auto-detects whether the
+input is JSON or PEG and prints the parse tree. With two arguments, it
+compiles the first file as a PEG grammar and uses it to parse the second.
+Demonstrates `JsonParser`, `PegParser`, `PegCompiler`, `Source`, `Printer`,
+and `PegFormatError`. Start here if you're new to the library.
+
+## [json.peg](json.peg)
+
+A JSON parser written in PEG file syntax. Shows the full range of PEG
+operators including the `-` (skip), `%` (separated list), and `?`
+(optional) extensions. Feed it to the compiler example to parse JSON
+files: `./compiler json.peg some_file.json`.
+
+## [peg.peg](peg.peg)
+
+A self-describing PEG grammar — a grammar that parses `.peg` files,
+written as a `.peg` file itself. Useful as a quick reference for the
+PEG file syntax and operator set.

--- a/peg/ast.pony
+++ b/peg/ast.pony
@@ -1,6 +1,12 @@
+// A child element in a parse tree: an AST subtree, a Token leaf, or
+// NotPresent (from an optional that didn't match).
 type ASTChild is (AST | Token | NotPresent)
 
 class val AST
+  """
+  A labeled node in the parse tree. Contains an ordered list of children
+  (other AST nodes, Tokens, or NotPresent values from optional matches).
+  """
   let _label: Label
   embed children: Array[ASTChild] = children.create()
 
@@ -8,11 +14,17 @@ class val AST
     _label = label'
 
   fun ref push(some: ASTChild) =>
+    """Append a child to this node."""
     children.push(some)
 
-  fun label(): Label => _label
+  fun label(): Label =>
+    """This node's label."""
+    _label
 
-  fun size(): USize => children.size()
+  fun size(): USize =>
+    """The number of children."""
+    children.size()
 
   fun extract(): ASTChild =>
+    """Return the first child, or `NotPresent` if there are none."""
     try children(0)? else NotPresent end

--- a/peg/eof.pony
+++ b/peg/eof.pony
@@ -1,4 +1,8 @@
 class EndOfFile is Parser
+  """
+  Wraps a parser and requires the entire input to be consumed after it
+  matches. If input remains after a successful parse, the parse fails.
+  """
   let _a: Parser
 
   new create(a: Parser) =>

--- a/peg/forward.pony
+++ b/peg/forward.pony
@@ -10,6 +10,7 @@ class Forward is Parser
     None
 
   fun ref update(value: Parser) =>
+    """Assign the real parser. Called via `()` sugar: `fwd() = real_parser`."""
     _a = value
 
   fun parse(source: Source, offset: USize, tree: Bool, hidden: Parser)
@@ -21,6 +22,8 @@ class Forward is Parser
       (0, this)
     end
 
-  fun complete(): Bool => _a isnt NoParser
+  fun complete(): Bool =>
+    """True if a real parser has been assigned via `update()`."""
+    _a isnt NoParser
 
   fun error_msg(): String => _a.error_msg()

--- a/peg/json.pony
+++ b/peg/json.pony
@@ -1,4 +1,9 @@
 primitive JsonParser
+  """
+  A JSON parser built from combinators. Supports standard JSON plus `//`, `#`,
+  and `/* ... */` comments (nested). The parse tree uses `TObject`, `TPair`,
+  `TArray`, `TString`, `TNumber`, `TBool`, and `TNull` labels.
+  """
   fun apply(): Parser val =>
     recover
       let obj = Forward
@@ -41,10 +46,20 @@ primitive JsonParser
       value.hide(hidden)
     end
 
+// AST labels for the JSON parser. Match on these when processing JSON parse
+// results.
+
+// A JSON object `{...}` containing zero or more `TPair` children.
 primitive TObject is Label fun text(): String => "Object"
+// A key-value pair in a JSON object: children are `TString` and a value.
 primitive TPair is Label fun text(): String => "Pair"
+// A JSON array `[...]` containing zero or more value children.
 primitive TArray is Label fun text(): String => "Array"
+// A JSON string value (including the surrounding quotes in the token).
 primitive TString is Label fun text(): String => "String"
+// A JSON number value.
 primitive TNumber is Label fun text(): String => "Number"
+// A JSON boolean (`true` or `false`).
 primitive TBool is Label fun text(): String => "Bool"
+// A JSON `null` value.
 primitive TNull is Label fun text(): String => "Null"

--- a/peg/literal.pony
+++ b/peg/literal.pony
@@ -1,6 +1,10 @@
+// Short alias for `Literal`.
 type L is Literal
 
 class Literal is Parser
+  """
+  Matches an exact string literal in the source text.
+  """
   let _text: String
 
   new val create(from: String) =>

--- a/peg/many.pony
+++ b/peg/many.pony
@@ -1,4 +1,13 @@
 class Many is Parser
+  """
+  Repetition parser with optional separator. Matches an element zero or more
+  times (or one or more when `require` is true). When a separator is provided,
+  elements must be separated by it and trailing separators are not allowed.
+
+  In PEG files: `e*` / `e+` for unseparated, `e % sep` / `e %+ sep` for
+  separated lists. In combinators: `e.many()` / `e.many1()` and
+  `e.many(sep)` / `e.many1(sep)`.
+  """
   let _a: Parser
   let _sep: Parser
   var _label: Label = NoLabel
@@ -9,8 +18,13 @@ class Many is Parser
     _sep = sep
     _require = require
 
-  fun label(): Label => _label
-  fun ref node(value: Label): Many => _label = value; this
+  fun label(): Label =>
+    """This repetition's label."""
+    _label
+
+  fun ref node(value: Label): Many =>
+    """Assign a label, creating a named AST node for this repetition."""
+    _label = value; this
 
   fun parse(source: Source, offset: USize, tree: Bool, hidden: Parser)
     : ParseResult

--- a/peg/option.pony
+++ b/peg/option.pony
@@ -1,4 +1,9 @@
 class Option is Parser
+  """
+  Optional match. If the wrapped parser succeeds, returns its result.
+  Otherwise, succeeds with `NotPresent` (consuming no input). Corresponds
+  to `e?` in PEG files and `e.opt()` in combinators.
+  """
   let _a: Parser
 
   new create(a: Parser) =>

--- a/peg/parser.pony
+++ b/peg/parser.pony
@@ -1,5 +1,9 @@
+// The result of a parse attempt: the number of bytes consumed and either a
+// successful parse (ParseOK) or the Parser that failed.
 type ParseResult is (USize, (ParseOK | Parser))
 
+// A successful parse result: an AST node, a Token leaf, NotPresent (from
+// Option), Skipped (from Skip/Not), or Lex (when tree building is off).
 type ParseOK is
   ( AST
   | Token
@@ -21,14 +25,29 @@ primitive Skipped
 
 primitive Lex
   """
-  Returned when a parse tree isn't neeeded
+  Returned when a parse tree isn't needed.
   """
 
 trait box Parser
+  """
+  A parsing expression that can be applied to source text. Parsers are composed
+  using operator sugar: `*` for sequence, `/` for ordered choice, `-` for skip,
+  and `not` for negation.
+  """
   fun parse(source: Source, offset: USize = 0, tree: Bool = true,
     hidden: Parser = NoParser): ParseResult
+    """
+    Parse `source` starting at byte `offset`. When `tree` is true, build an AST;
+    when false, only track the lexical position. The `hidden` parser defines
+    whitespace/comments to skip between tokens.
+    """
 
-  fun error_msg(): String => "not to see an error in this parser"
+  fun error_msg(): String =>
+    """
+    A human-readable description of what this parser expected. Used to build
+    error messages on parse failure.
+    """
+    "not to see an error in this parser"
 
   fun skip_hidden(source: Source, offset: USize, hidden: Parser): USize =>
     """
@@ -49,19 +68,56 @@ trait box Parser
       ((from - offset) + length, Lex)
     end
 
-  fun mul(that: Parser): Sequence => Sequence(this, that)
-  fun div(that: Parser): Choice => Choice(this, that)
-  fun neg(): Skip => Skip(this)
-  fun opt(): Option => Option(this)
-  fun many(sep: Parser = NoParser): Many => Many(this, sep, false)
-  fun many1(sep: Parser = NoParser): Many => Many(this, sep, true)
-  fun op_not(): Not => Not(this)
-  fun op_and(): Not => Not(Not(this))
-  fun hide(that: Parser): Hidden => Hidden(this, that)
-  fun term(l: Label = NoLabel): Terminal => Terminal(this, l)
-  fun eof(): EndOfFile => EndOfFile(this)
+  fun mul(that: Parser): Sequence =>
+    """Sequence operator: `a * b` matches a then b."""
+    Sequence(this, that)
+
+  fun div(that: Parser): Choice =>
+    """Ordered choice operator: `a / b` tries a first, then b."""
+    Choice(this, that)
+
+  fun neg(): Skip =>
+    """Skip operator: `-a` matches a but omits it from the tree."""
+    Skip(this)
+
+  fun opt(): Option =>
+    """Option: `a.opt()` matches a or succeeds with `NotPresent`."""
+    Option(this)
+
+  fun many(sep: Parser = NoParser): Many =>
+    """Zero or more: `a.many()` or `a.many(sep)` for separated lists."""
+    Many(this, sep, false)
+
+  fun many1(sep: Parser = NoParser): Many =>
+    """One or more: `a.many1()` or `a.many1(sep)` for separated lists."""
+    Many(this, sep, true)
+
+  fun op_not(): Not =>
+    """Not predicate: `not a` succeeds if a fails, consuming nothing."""
+    Not(this)
+
+  fun op_and(): Not =>
+    """And predicate: succeeds if a matches, consuming nothing."""
+    Not(Not(this))
+
+  fun hide(that: Parser): Hidden =>
+    """Set the hidden channel (whitespace/comments) for this parser."""
+    Hidden(this, that)
+
+  fun term(l: Label = NoLabel): Terminal =>
+    """Wrap as a terminal that produces a single `Token` leaf."""
+    Terminal(this, l)
+
+  fun eof(): EndOfFile =>
+    """Require the entire input to be consumed after this parser."""
+    EndOfFile(this)
 
 primitive NoParser is Parser
+  """
+  A null parser that matches nothing. Used as a default/sentinel value where
+  a parser is required but none is active (e.g. default hidden channel, default
+  separator in `Many`).
+  """
   fun parse(source: Source, offset: USize, tree: Bool, hidden: Parser)
     : ParseResult
   =>
@@ -70,6 +126,12 @@ primitive NoParser is Parser
   fun error_msg(): String => "not to be using NoParser"
 
 trait val Label
+  """
+  A label identifies AST nodes and tokens in the parse tree. Define custom
+  labels as primitives implementing this trait to tag your grammar's rules.
+  """
   fun text(): String
 
-primitive NoLabel is Label fun text(): String => ""
+primitive NoLabel is Label
+  """The default empty label, used when no label has been assigned."""
+  fun text(): String => ""

--- a/peg/peg.pony
+++ b/peg/peg.pony
@@ -1,0 +1,170 @@
+"""
+# Peg Package
+
+A Parsing Expression Grammar (PEG) library for Pony. It provides two ways to
+define parsers: writing a `.peg` grammar file that is compiled at runtime, or
+building parsers directly in Pony code using combinators.
+
+## PEG File Mode
+
+Write a grammar in a `.peg` file, then compile it with `PegCompiler`:
+
+```pony
+use "peg"
+use "files"
+
+actor Main
+  new create(env: Env) =>
+    try
+      let auth = FileAuth(env.root)
+      let source = Source(FilePath(auth, "my_grammar.peg"))?
+
+      match recover val PegCompiler(source) end
+      | let parser: Parser val =>
+        let input = Source.from_string("some input text")
+        match recover val parser.parse(input) end
+        | (_, let ast: AST) => env.out.print(recover val Printer(ast) end)
+        | (let offset: USize, let r: Parser val) =>
+          let e = recover val SyntaxError(input, offset, r) end
+          env.out.writev(PegFormatError.console(e))
+        end
+      | let errors: Array[PegError] val =>
+        for e in errors.values() do
+          env.out.writev(PegFormatError.console(e))
+        end
+      end
+    end
+```
+
+Use PEG file mode when grammars are user-supplied, loaded from disk, or when
+you want to iterate on the grammar without recompiling Pony code.
+
+## Combinator Mode
+
+Build parsers directly in Pony using `L` (literal), `R` (unicode range),
+`Unicode`, and operators:
+
+```pony
+use "peg"
+
+actor Main
+  new create(env: Env) =>
+    let digit = R('0', '9')
+    let number = digit.many1().term(TNumber)
+    let op = (L("+") / L("-") / L("*") / L("/")).term(TOp)
+    let expr = (number * op * number).node(TExpr)
+    let whitespace = (L(" ") / L("\t")).many1()
+    let parser = recover val expr.hide(whitespace) end
+
+    let source = Source.from_string("42 + 7")
+    match recover val parser.parse(source) end
+    | (_, let ast: AST) => env.out.print(recover val Printer(ast) end)
+    | (let offset: USize, let r: Parser val) =>
+      let e = recover val SyntaxError(source, offset, r) end
+      env.out.writev(PegFormatError.console(e))
+    end
+
+primitive TNumber is Label fun text(): String => "Number"
+primitive TOp is Label fun text(): String => "Op"
+primitive TExpr is Label fun text(): String => "Expr"
+```
+
+Use combinator mode when the grammar is fixed at compile time and you want
+full type safety and IDE support.
+
+## PEG File Grammar Reference
+
+Rules are defined as `name <- expression` and separated by whitespace.
+Comments use `//`, `#`, or `/* ... */` (nested comments are supported).
+
+### Operators
+
+| Syntax | Name | Description |
+|---|---|---|
+| `"text"` | String literal | Matches the exact string |
+| `'c'` | Character literal | Matches a single character |
+| `.` | Any | Matches any character (codepoint >= space) |
+| `'a'..'z'` | Range | Matches a character in the codepoint range |
+| `e1 e2` | Sequence | Matches e1 followed by e2 |
+| `e1 / e2` | Ordered choice | Tries e1 first, then e2 if e1 fails |
+| `e?` | Option | Matches e or succeeds with nothing |
+| `e*` | Zero or more | Matches e repeatedly (zero or more times) |
+| `e+` | One or more | Matches e repeatedly (at least once) |
+| `!e` | Not predicate | Succeeds (consuming nothing) if e fails |
+| `&e` | And predicate | Succeeds (consuming nothing) if e matches |
+| `-e` | Skip (extension) | Matches e but omits it from the parse tree |
+| `e % sep` | Separated list (extension) | Zero or more e separated by sep |
+| `e %+ sep` | Separated list (extension) | One or more e separated by sep |
+
+The `-`, `%`, and `%+` operators are extensions beyond standard PEG.
+
+### Reserved Rule Names
+
+- `start` — required entry point; parsing begins here
+- `hidden` — defines the whitespace/comment channel; tokens matching
+  this rule are automatically skipped between other tokens
+
+### Naming Convention
+
+- **Uppercase** rule names (e.g. `NUMBER`, `STRING`) produce terminal tokens:
+  the matched text becomes a single `Token` leaf node
+- **Lowercase** rule names (e.g. `value`, `pair`) produce `AST` nodes with
+  children
+
+## Combinator API
+
+The combinators mirror the PEG file operators:
+
+| PEG file | Pony combinator |
+|---|---|
+| `"text"` / `'c'` | `L("text")` |
+| `.` | `R(' ')` (`Unicode` matches all codepoints) |
+| `'a'..'z'` | `R('a', 'z')` |
+| `e1 e2` | `e1 * e2` |
+| `e1 / e2` | `e1 / e2` |
+| `e?` | `e.opt()` |
+| `e*` | `e.many()` |
+| `e+` | `e.many1()` |
+| `!e` | `not e` |
+| `&e` | `not not e` |
+| `-e` | `-e` |
+| `e % sep` | `e.many(sep)` |
+| `e %+ sep` | `e.many1(sep)` |
+| Terminal rule | `e.term(MyLabel)` |
+| Non-terminal rule | `e.node(MyLabel)` (on `Sequence` or `Many`) |
+| Hidden channel | `e.hide(hidden_parser)` |
+| End of file | `e.eof()` |
+| Recursive rule | `Forward` + `update()` |
+
+## Parse Results
+
+Calling `Parser.parse()` returns a `ParseResult`, which is
+`(USize, (ParseOK | Parser))`:
+
+- Success: the second element is one of:
+  - `AST` — a labeled tree node with children
+  - `Token` — a leaf node with matched source text
+  - `NotPresent` — returned by `Option` when the optional parse is absent
+  - `Skipped` — returned by `Skip` (and `Not` on success)
+- Failure: the second element is the `Parser` that failed, and the `USize`
+  is the byte offset where it failed. Wrap in `SyntaxError` and format
+  with `PegFormatError.console()` for display.
+
+## Forward References
+
+Use `Forward` to create mutually recursive grammars. Create the `Forward`
+first, use it in other rules, then assign the real rule with `update()`:
+
+```pony
+let expr = Forward
+let group = -L("(") * expr * -L(")")
+expr() = group / some_other_rule  // () is sugar for update()
+```
+
+## Built-in Parsers
+
+- `JsonParser` — a JSON parser built from combinators, with comment support
+- `PegParser` — the parser for `.peg` grammar files (used by `PegCompiler`)
+
+See the `examples/` directory for a CLI tool that demonstrates both.
+"""

--- a/peg/pegcompiler.pony
+++ b/peg/pegcompiler.pony
@@ -1,10 +1,21 @@
 use "term"
 use "collections"
 
+// Internal map from rule name to its Forward parser and defining token.
 type Defs is Map[String, (Forward, Token)]
 
 primitive PegCompiler
+  """
+  Compiles a PEG grammar source into an executable `Parser`. Returns either
+  the compiled parser or an array of errors found during compilation. The
+  grammar must define a `start` rule and may define a `hidden` rule for
+  whitespace/comments.
+  """
   fun apply(source: Source): (Parser | Array[PegError]) =>
+    """
+    Compile `source` as a PEG grammar. On success, returns a `Parser val`
+    ready to parse input. On failure, returns the accumulated errors.
+    """
     let p: Parser = PegParser().eof()
     let errors = Array[PegError]
 
@@ -200,6 +211,11 @@ primitive PegCompiler
     end
 
 class val PegLabel is Label
+  """
+  A label created at runtime from a rule name in a compiled PEG grammar.
+  Unlike the primitive labels used in combinator-built parsers, these are
+  class instances with string-based identity.
+  """
   let _text: String
 
   new val create(text': String) =>

--- a/peg/pegerror.pony
+++ b/peg/pegerror.pony
@@ -1,14 +1,26 @@
 use "collections"
 use "term"
 
+// An error marker: (source, byte offset, length, message). Used by
+// PegFormatError to point at specific locations in the source text.
 type Marker is (Source, USize, USize, String)
 
 trait box PegError
+  """
+  Base trait for errors produced during parsing or grammar compilation.
+  """
+  // Short category name (e.g. "Syntax Error", "Missing Definition").
   fun category(): String
+  // Human-readable explanation of the error.
   fun description(): String
+  // Source locations related to this error, with explanatory messages.
   fun markers(): Iterator[Marker] => Array[Marker].values()
 
 class SyntaxError is PegError
+  """
+  A parse failed at a specific offset. Wraps the failing parser so its
+  `error_msg()` can describe what was expected.
+  """
   let source: Source
   let offset: USize
   let parser: Parser
@@ -30,6 +42,7 @@ class SyntaxError is PegError
     [(source, offset, USize(1), "expected " + parser.error_msg())].values()
 
 class val DuplicateDefinition is PegError
+  """A rule name was defined more than once in a PEG grammar."""
   let def: Token
   let prev: Token
 
@@ -50,6 +63,7 @@ class val DuplicateDefinition is PegError
     ].values()
 
 class val MissingDefinition is PegError
+  """A rule references another rule that has not been defined."""
   let token: Token
 
   new val create(token': Token) =>
@@ -67,6 +81,7 @@ class val MissingDefinition is PegError
     ].values()
 
 class val UnknownNodeLabel is PegError
+  """An unrecognized label was encountered in the PEG AST during compilation."""
   let label: Label
 
   new val create(label': Label) =>
@@ -81,6 +96,7 @@ class val UnknownNodeLabel is PegError
     """
 
 primitive NoStartDefinition is PegError
+  """The grammar has no `start` rule."""
   fun category(): String => "No Start Rule"
   fun description(): String =>
     """
@@ -89,6 +105,7 @@ primitive NoStartDefinition is PegError
     """
 
 primitive MalformedAST is PegError
+  """The PEG AST has a structure the compiler does not understand."""
   fun category(): String => "Malformed AST"
   fun description(): String =>
     """
@@ -97,7 +114,14 @@ primitive MalformedAST is PegError
     """
 
 primitive PegFormatError
+  """
+  Formats `PegError` values for display on a terminal or as JSON.
+  """
   fun console(e: PegError val, colorize: Bool = true): ByteSeqIter =>
+    """
+    Format an error for terminal output. Set `colorize` to false to omit
+    ANSI escape sequences (useful when piping to non-terminal destinations).
+    """
     let text =
       recover
         [ if colorize then ANSI.cyan() else "" end
@@ -148,6 +172,7 @@ primitive PegFormatError
     text
 
   fun json(e: PegError val): ByteSeqIter =>
+    """Format an error as a JSON object."""
     let text =
       recover
         [ "{\n  \"category\": \""

--- a/peg/pegparser.pony
+++ b/peg/pegparser.pony
@@ -1,4 +1,9 @@
 primitive PegParser
+  """
+  The built-in parser for `.peg` grammar files. Used internally by
+  `PegCompiler` to parse grammar source before compilation. Supports
+  `//`, `#`, and `/* ... */` comments (nested).
+  """
   fun apply(): Parser val =>
     recover
       let digit = R('0', '9')
@@ -53,20 +58,40 @@ primitive PegParser
       definition.many1().node(PegGrammar).hide(hidden)
     end
 
+// AST labels for the PEG grammar parser. These are internal labels used by
+// PegParser and PegCompiler to represent the structure of a .peg file's AST.
+
+// A quoted string literal in a PEG grammar.
 primitive PegString is Label fun text(): String => "String"
+// A single-quoted character literal in a PEG grammar.
 primitive PegChar is Label fun text(): String => "Char"
+// The `.` (any character) operator in a PEG grammar.
 primitive PegAny is Label fun text(): String => "Any"
+// A rule name reference in a PEG grammar.
 primitive PegIdent is Label fun text(): String => "Ident"
+// A character range (`'a'..'z'`) in a PEG grammar.
 primitive PegRange is Label fun text(): String => "Range"
+// An optional (`?`) expression in a PEG grammar.
 primitive PegOpt is Label fun text(): String => "Opt"
+// A zero-or-more (`*`) expression in a PEG grammar.
 primitive PegMany is Label fun text(): String => "Many"
+// A one-or-more (`+`) expression in a PEG grammar.
 primitive PegMany1 is Label fun text(): String => "Many1"
+// A separated list (`%`) expression in a PEG grammar.
 primitive PegSep is Label fun text(): String => "Sep"
+// A required separated list (`%+`) expression in a PEG grammar.
 primitive PegSep1 is Label fun text(): String => "Sep1"
+// An and-predicate (`&`) expression in a PEG grammar.
 primitive PegAnd is Label fun text(): String => "And"
+// A not-predicate (`!`) expression in a PEG grammar.
 primitive PegNot is Label fun text(): String => "Not"
+// A skip (`-`) expression in a PEG grammar.
 primitive PegSkip is Label fun text(): String => "Skip"
+// A sequence of expressions in a PEG grammar.
 primitive PegSeq is Label fun text(): String => "Seq"
+// An ordered choice (`/`) expression in a PEG grammar.
 primitive PegChoice is Label fun text(): String => "Choice"
+// A rule definition (`name <- expr`) in a PEG grammar.
 primitive PegDef is Label fun text(): String => "Def"
+// The top-level node containing all rule definitions.
 primitive PegGrammar is Label fun text(): String => "Grammar"

--- a/peg/position.pony
+++ b/peg/position.pony
@@ -1,7 +1,12 @@
 use "collections"
 
 primitive Position
+  """
+  Converts byte offsets in source text to line/column positions. Used by
+  `PegFormatError` to produce human-readable error locations.
+  """
   fun apply(source: Source, offset: USize): (USize, USize) =>
+    """Return the (line, column) for a byte offset in `source`."""
     var cr = false
     var line = USize(1)
     var col = USize(1)
@@ -30,6 +35,7 @@ primitive Position
     (line, col)
 
   fun text(source: Source, offset: USize, col: USize): String =>
+    """Return the source line containing the given offset."""
     let start = ((offset - col) + 1).isize()
     let finish =
       try
@@ -40,6 +46,7 @@ primitive Position
     source.content.substring(start, finish)
 
   fun indent(line: String, col: USize): String =>
+    """Build a whitespace string matching the indentation up to `col`."""
     recover
       let s = String
       try

--- a/peg/printer.pony
+++ b/peg/printer.pony
@@ -1,9 +1,18 @@
 use "collections"
 
 primitive Printer
+  """
+  Pretty-prints a parse tree as indented S-expressions. Each node is printed
+  as `(label ...)` with children indented below it; tokens are printed as
+  `(label text)` on a single line.
+  """
   fun apply(p: ASTChild, depth: USize = 0, indent: String = "  ",
     s: String ref = String): String ref
   =>
+    """
+    Print the parse tree rooted at `p`. Pass a `String ref` as `s` to
+    append to an existing buffer; otherwise a new string is allocated.
+    """
     _indent(depth, indent, s)
     s.append("(")
     s.append(p.label().text())

--- a/peg/sequence.pony
+++ b/peg/sequence.pony
@@ -1,4 +1,11 @@
 class Sequence is Parser
+  """
+  An ordered sequence of parsers that must all match in order. Built with
+  the `*` operator: `a * b * c`.
+
+  When a `Sequence` has no label, its children are inlined into the parent
+  node. Assign a label with `node()` to create a distinct AST node.
+  """
   let _seq: Array[Parser]
   var _label: Label
 
@@ -12,8 +19,13 @@ class Sequence is Parser
     _seq = consume r
     _label = a._label
 
-  fun label(): Label => _label
-  fun ref node(value: Label): Sequence => _label = value; this
+  fun label(): Label =>
+    """This sequence's label."""
+    _label
+
+  fun ref node(value: Label): Sequence =>
+    """Assign a label, creating a named AST node for this sequence."""
+    _label = value; this
 
   fun mul(that: Parser): Sequence =>
     concat(this, that)

--- a/peg/skip.pony
+++ b/peg/skip.pony
@@ -1,4 +1,10 @@
 class Skip is Parser
+  """
+  Matches the wrapped parser but omits it from the parse tree, returning
+  `Skipped` on success. This is a PEG extension (`-e` in PEG files, `-e`
+  in combinators) used for syntactic punctuation like brackets and keywords
+  that are needed for parsing but carry no semantic value.
+  """
   let _a: Parser
 
   new create(a: Parser) =>

--- a/peg/source.pony
+++ b/peg/source.pony
@@ -1,14 +1,20 @@
 use "files"
 
 class val Source
+  """
+  Wraps source text for parsing. Create from a file path with `Source(path)?`
+  or from a string with `Source.from_string(text)`.
+  """
   let path: String
   let content: String
 
   new val create(filepath: FilePath) ? =>
+    """Load source text from a file. Errors if the file cannot be opened."""
     path = filepath.path
     let file = OpenFile(filepath) as File
     content = file.read_string(file.size())
     file.dispose()
 
   new val from_string(content': String, path': String = "") =>
+    """Create source from an in-memory string."""
     (path, content) = (path', content')

--- a/peg/token.pony
+++ b/peg/token.pony
@@ -1,4 +1,9 @@
 class val Token
+  """
+  A leaf node in the parse tree representing a span of matched source text.
+  The token stores a reference to the source and the byte offset/length of
+  the match rather than copying the text.
+  """
   let _label: Label
   let source: Source
   let offset: USize
@@ -11,14 +16,19 @@ class val Token
     offset = offset'
     length = length'
 
-  fun label(): Label => _label
+  fun label(): Label =>
+    """This token's label."""
+    _label
 
   fun string(): String iso^ =>
+    """The full matched text."""
     source.content.substring(offset.isize(), (offset + length).isize())
 
   fun substring(from: ISize, to: ISize): String iso^ =>
+    """A substring of the matched text. Negative indices count from the end."""
     source.content.substring(
       offset_to_index(from).isize(), offset_to_index(to).isize())
 
   fun offset_to_index(i: ISize): USize =>
+    """Convert a relative index to an absolute source position."""
     if i < 0 then offset + length + i.usize() else offset + i.usize() end

--- a/peg/unicode.pony
+++ b/peg/unicode.pony
@@ -1,4 +1,9 @@
 primitive Unicode is Parser
+  """
+  Matches any single valid Unicode character. Note that in PEG files, the `.`
+  operator compiles to `R(' ')` instead, which excludes control characters
+  below U+0020.
+  """
   fun parse(source: Source, offset: USize, tree: Bool, hidden: Parser)
     : ParseResult
   =>
@@ -13,9 +18,14 @@ primitive Unicode is Parser
 
   fun error_msg(): String => "a unicode character"
 
+// Short alias for `UnicodeRange`.
 type R is UnicodeRange
 
 class UnicodeRange is Parser
+  """
+  Matches any single Unicode character whose codepoint falls within the given
+  range (the `'a'..'z'` operator in PEG files).
+  """
   let _low: U32
   let _hi: U32
 


### PR DESCRIPTION
Adds comprehensive documentation to the peg library, addressing all four
gaps identified in #46: no prescriptive usage guide, no grammar/operator
reference, minimal source docstrings, and undocumented PEG extensions.

The main addition is a package docstring (`peg/peg.pony`) that serves as
the entry point in generated API docs. It covers both usage modes (PEG
file compiler and Pony combinators) with complete code examples, a grammar
reference table marking the `-`, `%`, and `%+` extensions, and a
combinator API mapping table.

Every public class, trait, primitive, and their public methods now have
docstrings. Type aliases and one-line label primitives use comments since
they can't carry docstrings in Pony.

Also fixes a typo in the `Lex` docstring ("neeeded" -> "needed") and adds
an `examples/README.md`.

Closes #46