### PR TITLE
Rename build-examples make target to examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -maxdepth 0 -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)
 EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 
-test: unit-tests build-examples
+test: unit-tests examples
 
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
@@ -37,7 +37,7 @@ $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
 
-build-examples: $(EXAMPLES_BINARIES)
+examples: $(EXAMPLES_BINARIES)
 
 $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
@@ -62,4 +62,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all build-examples clean TAGS test
+.PHONY: all examples clean TAGS test

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ primitive TNull is Label fun text(): String => "Null"
 ## Executable Parser Compiler
 
 An executable example of the parser compiler is found in examples/compiler.
-You can compile the executable by running `make build-examples`.
+You can compile the executable by running `make examples`.
 
 ```console
 Usage:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
 Each entry demonstrates a different aspect of the peg library. Build all
-examples with `make build-examples`.
+examples with `make examples`.
 
 ## [compiler](compiler/)
 


### PR DESCRIPTION
Shorter, more natural target name.