### PR TITLE
Fix unreachable sep rule in self-describing PEG grammar

### DIFF
--- a/.release-notes/fix-peg-grammar-sep.md
+++ b/.release-notes/fix-peg-grammar-sep.md
@@ -1,0 +1,3 @@
+## Fix unreachable sep rule in self-describing PEG grammar
+
+The `sep` rule (for the `%` separated-list-zero-or-more operator) was defined in `examples/peg.peg` but never referenced in `suffix`, making it unreachable. Only `%+` (one or more) was reachable via `sep1`. The `suffix` rule now includes `sep`.

--- a/examples/peg.peg
+++ b/examples/peg.peg
@@ -24,7 +24,7 @@ many <- primary -"*"
 many1 <- primary -"+"
 sep <- primary -"%" primary
 sep1 <- primary -"%+" primary
-suffix <- option / many / many1 / sep1 / primary
+suffix <- option / many / many1 / sep1 / sep / primary
 and <- -"&" suffix
 not <- -"!" suffix
 skip <- -"-" suffix


### PR DESCRIPTION
The `sep` rule (for the `%` separated-list-zero-or-more operator) was defined in `examples/peg.peg` but never referenced in `suffix`, making it unreachable. Only `%+` (one or more) was reachable via `sep1`. Added `sep` to the `suffix` ordered choice, after `sep1` so the longer `%+` match takes priority.

Closes #56