### PR TITLE
Update to work with ponyc 0.61.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,11 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-release:
-    name: Test against recent ponyc release
+  vs-ponyc-nightly:
+    name: Test against ponyc nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.release-notes/update-to-ponyc-0.61.1.md
+++ b/.release-notes/update-to-ponyc-0.61.1.md
@@ -1,0 +1,4 @@
+## Update to work with ponyc 0.61.1
+
+ponyc 0.61.1 now detects exhaustive match blocks and treats unreachable `else` clauses as compile errors. peg has been updated to remove these unreachable `else` clauses, which means peg now requires ponyc 0.61.1 or newer.
+

--- a/peg/eof.pony
+++ b/peg/eof.pony
@@ -20,8 +20,6 @@ class EndOfFile is Parser
         (from - offset, this)
       end
     | (let advance: USize, let r: Parser) => (advance, r)
-    else
-      (0, this)
     end
 
   fun error_msg(): String => "end-of-file"

--- a/peg/hidden.pony
+++ b/peg/hidden.pony
@@ -19,6 +19,4 @@ class Hidden is Parser
       let from = skip_hidden(source, offset + advance, _hide)
       (from - offset, r)
     | (let advance: USize, let r: Parser) => (advance, r)
-    else
-      (0, this)
     end

--- a/peg/skip.pony
+++ b/peg/skip.pony
@@ -16,8 +16,6 @@ class Skip is Parser
     match _a.parse(source, offset, false, hidden)
     | (let advance: USize, let r: ParseOK) => (advance, Skipped)
     | (let advance: USize, let r: Parser) => (advance, r)
-    else
-      (0, this)
     end
 
   fun error_msg(): String => _a.error_msg()


### PR DESCRIPTION
ponyc nightly now detects exhaustive match blocks and treats unreachable else clauses as errors. The match blocks in Skip, Hidden, and EndOfFile cover both ParseOK and Parser — the full ParseResult union — making the else dead code.

Also switches the PR workflow to nightly since the release compiler doesn't have this detection yet.