### PR TITLE
Add test-one Makefile target for running individual tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ test: unit-tests examples
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
 
+test-one: $(tests_binary)
+	$^ --only="$(t)"
+
 $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
@@ -63,4 +66,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all examples clean TAGS test
+.PHONY: all examples clean TAGS test test-one


### PR DESCRIPTION
Adds a `test-one` target that runs a single test by name using ponytest's `--only` flag:

```
make test-one t=TestName
```

Avoids full suite runs when iterating on a specific test during development or debugging.