### PR TITLE
Switch CI from ponyc nightly to release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,11 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-nightly:
-    name: Test against ponyc nightly
+  vs-ponyc-release:
+    name: Test against ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
ponyc 0.61.1 has been released. Switch CI jobs back to using the release version of ponyc.